### PR TITLE
Get rid of reference to BufferImpl.EMPTY and dependency on embulk-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,12 +19,10 @@ configurations {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.7"
-    compileOnly "org.embulk:embulk-core:0.10.7"
+    compileOnly "org.embulk:embulk-api:0.10.8"
 }
 
 tasks.withType(JavaCompile) {
@@ -44,6 +42,7 @@ javadoc {
         locale = "en_US"
         encoding = "UTF-8"
         links "https://docs.oracle.com/javase/8/docs/api/"
+        links "https://dev.embulk.org/embulk-api/0.10.8/javadoc/"
     }
 }
 

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,27 +1,4 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-aopalliance:aopalliance:1.0
-com.fasterxml.jackson.core:jackson-annotations:2.6.7
-com.fasterxml.jackson.core:jackson-core:2.6.7
-com.fasterxml.jackson.core:jackson-databind:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.7
-com.fasterxml.jackson.module:jackson-module-guice:2.6.7
-com.google.guava:guava:18.0
-com.google.inject.extensions:guice-multibindings:4.0
-com.google.inject:guice:4.0
-commons-beanutils:commons-beanutils-core:1.8.3
-javax.inject:javax.inject:1
-javax.validation:validation-api:1.1.0.Final
-joda-time:joda-time:2.9.2
-org.apache.bval:bval-core:0.5
-org.apache.bval:bval-jsr303:0.5
-org.apache.commons:commons-lang3:3.4
-org.embulk:embulk-api:0.10.7
-org.embulk:embulk-core:0.10.7
-org.embulk:embulk-spi:0.10.7
-org.jruby:jruby-complete:9.1.15.0
-org.msgpack:msgpack-core:0.8.11
-org.slf4j:slf4j-api:1.7.12
+org.embulk:embulk-api:0.10.8

--- a/src/main/java/org/embulk/util/file/EmptyBuffer.java
+++ b/src/main/java/org/embulk/util/file/EmptyBuffer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.file;
+
+import org.embulk.spi.Buffer;
+
+final class EmptyBuffer extends Buffer {
+    EmptyBuffer() {
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public byte[] array() {
+        return EMPTY_BYTES;
+    }
+
+    @Override
+    public int offset() {
+        return 0;
+    }
+
+    @Override
+    public Buffer offset(final int offset) {
+        return this;
+    }
+
+    @Override
+    public int limit() {
+        return 0;
+    }
+
+    @Override
+    public Buffer limit(final int limit) {
+        return this;
+    }
+
+    @Override
+    public int capacity() {
+        return 0;
+    }
+
+    @Override
+    public void setBytes(int index, byte[] source, int sourceIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void setBytes(int index, Buffer source, int sourceIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void getBytes(int index, byte[] dest, int destIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void getBytes(int index, Buffer dest, int destIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void release() {
+        return;
+    }
+
+    static final EmptyBuffer INSTANCE = new EmptyBuffer();
+
+    private static final byte[] EMPTY_BYTES = new byte[0];
+}

--- a/src/main/java/org/embulk/util/file/FileInputInputStream.java
+++ b/src/main/java/org/embulk/util/file/FileInputInputStream.java
@@ -18,13 +18,12 @@ package org.embulk.util.file;
 
 import java.io.InputStream;
 import org.embulk.spi.Buffer;
-import org.embulk.spi.BufferImpl;
 import org.embulk.spi.FileInput;
 
 public class FileInputInputStream extends InputStream {
     public FileInputInputStream(final FileInput in) {
         this.pos = 0;
-        this.buffer = BufferImpl.EMPTY;
+        this.buffer = EmptyBuffer.INSTANCE;
 
         this.in = in;
     }
@@ -113,7 +112,7 @@ public class FileInputInputStream extends InputStream {
 
     private void releaseBuffer() {
         this.buffer.release();
-        this.buffer = BufferImpl.EMPTY;
+        this.buffer = EmptyBuffer.INSTANCE;
         this.pos = 0;
     }
 

--- a/src/main/java/org/embulk/util/file/FileOutputOutputStream.java
+++ b/src/main/java/org/embulk/util/file/FileOutputOutputStream.java
@@ -19,7 +19,6 @@ package org.embulk.util.file;
 import java.io.OutputStream;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.BufferAllocator;
-import org.embulk.spi.BufferImpl;
 import org.embulk.spi.FileOutput;
 
 public class FileOutputOutputStream extends OutputStream {
@@ -87,7 +86,7 @@ public class FileOutputOutputStream extends OutputStream {
         if (this.pos > 0) {
             this.buffer.limit(this.pos);
             this.out.add(this.buffer);
-            this.buffer = BufferImpl.EMPTY;
+            this.buffer = EmptyBuffer.INSTANCE;
             this.pos = 0;
             return true;
         }
@@ -122,7 +121,7 @@ public class FileOutputOutputStream extends OutputStream {
             default:  // Never default as all enums are listed.
         }
         this.buffer.release();
-        this.buffer = BufferImpl.EMPTY;
+        this.buffer = EmptyBuffer.INSTANCE;
         this.pos = 0;
     }
 


### PR DESCRIPTION
Those classes have been directly accessing embulk-core's internal `BufferImpl`, but they should not access it as an external library.

Instead of `BufferImpl.EMPTY`, it implements its own "empty `Buffer`" by itself.