### PR TITLE
Use the compatible constructor Buffer(byte[], int, int) when Buffer() does not exist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.8"
+    compileOnly "org.embulk:embulk-api:0.10.28"
 }
 
 tasks.withType(JavaCompile) {

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,4 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.embulk:embulk-api:0.10.8
+org.embulk:embulk-api:0.10.28
+org.msgpack:msgpack-core:0.8.11
+org.slf4j:slf4j-api:1.7.30

--- a/src/main/java/org/embulk/util/file/EmptyBuffer.java
+++ b/src/main/java/org/embulk/util/file/EmptyBuffer.java
@@ -18,67 +18,40 @@ package org.embulk.util.file;
 
 import org.embulk.spi.Buffer;
 
-final class EmptyBuffer extends Buffer {
-    EmptyBuffer() {
+final class EmptyBuffer {
+    private EmptyBuffer() {}
+
+    static Buffer getInstance() {
+        return Holder.INSTANCE;
     }
 
-    @SuppressWarnings("deprecation")
-    @Override
-    public byte[] array() {
-        return EMPTY_BYTES;
+    private static class Holder {  // Initialization-on-demand holder idiom.
+        private static final Buffer INSTANCE = createInstance();
+
+        private static Buffer createInstance() {
+            // EmptyBufferCompat and EmptyBufferUpToDate are implemented as separate independent classes while
+            // they have the same methods so that this library can work both with Embulk v0.9 and v0.10.
+            //
+            // EmptyBufferUpToDate depends on the constructor |Buffer()| of the latest abstract org.embulk.spi.Buffer.
+            // https://github.com/embulk/embulk/blob/v0.10.27/embulk-api/src/main/java/org/embulk/spi/Buffer.java#L38-L39
+            //
+            // It is basically recommended in Embulk v0.10 and later, but it did not exist in Embulk v0.9 or earlier.
+            // Embulk v0.9 had only the constructor |Buffer(byte[], int, int)| of org.embulk.spi.Buffer.
+            // https://github.com/embulk/embulk/blob/v0.9.23/embulk-core/src/main/java/org/embulk/spi/Buffer.java
+            //
+            // EmptyBufferCompat is implemented to depend on |Buffer(byte[], int, int)| to work with Embulk v0.9.
+            //
+            // They are implemented as separate independent classes because one can fail when the class is initialized
+            // if its constructor is depending on a non-existing super-class constructor. They would never fail unless
+            // the class is initialized / loaded.
+            try {
+                Buffer.class.getConstructor();  // throws NoSuchMethodException if working with v0.9.
+                return new EmptyBufferUpToDate();
+            } catch (final NoSuchMethodException ex) {
+                // Pass-through.
+            }
+
+            return new EmptyBufferCompat();
+        }
     }
-
-    @Override
-    public int offset() {
-        return 0;
-    }
-
-    @Override
-    public Buffer offset(final int offset) {
-        return this;
-    }
-
-    @Override
-    public int limit() {
-        return 0;
-    }
-
-    @Override
-    public Buffer limit(final int limit) {
-        return this;
-    }
-
-    @Override
-    public int capacity() {
-        return 0;
-    }
-
-    @Override
-    public void setBytes(int index, byte[] source, int sourceIndex, int length) {
-        return;
-    }
-
-    @Override
-    public void setBytes(int index, Buffer source, int sourceIndex, int length) {
-        return;
-    }
-
-    @Override
-    public void getBytes(int index, byte[] dest, int destIndex, int length) {
-        return;
-    }
-
-    @Override
-    public void getBytes(int index, Buffer dest, int destIndex, int length) {
-        return;
-    }
-
-    @Override
-    public void release() {
-        return;
-    }
-
-    static final EmptyBuffer INSTANCE = new EmptyBuffer();
-
-    private static final byte[] EMPTY_BYTES = new byte[0];
 }

--- a/src/main/java/org/embulk/util/file/EmptyBufferCompat.java
+++ b/src/main/java/org/embulk/util/file/EmptyBufferCompat.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.file;
+
+import org.embulk.spi.Buffer;
+
+final class EmptyBufferCompat extends Buffer {
+    @SuppressWarnings("deprecation")
+    EmptyBufferCompat() {
+        super(EMPTY_BYTES, 0, 0);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public byte[] array() {
+        return EMPTY_BYTES;
+    }
+
+    @Override
+    public int offset() {
+        return 0;
+    }
+
+    @Override
+    public Buffer offset(final int offset) {
+        return this;
+    }
+
+    @Override
+    public int limit() {
+        return 0;
+    }
+
+    @Override
+    public Buffer limit(final int limit) {
+        return this;
+    }
+
+    @Override
+    public int capacity() {
+        return 0;
+    }
+
+    @Override
+    public void setBytes(int index, byte[] source, int sourceIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void setBytes(int index, Buffer source, int sourceIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void getBytes(int index, byte[] dest, int destIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void getBytes(int index, Buffer dest, int destIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void release() {
+        return;
+    }
+
+    private static final byte[] EMPTY_BYTES = new byte[0];
+}

--- a/src/main/java/org/embulk/util/file/EmptyBufferUpToDate.java
+++ b/src/main/java/org/embulk/util/file/EmptyBufferUpToDate.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.file;
+
+import org.embulk.spi.Buffer;
+
+final class EmptyBufferUpToDate extends Buffer {
+    EmptyBufferUpToDate() {
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public byte[] array() {
+        return EMPTY_BYTES;
+    }
+
+    @Override
+    public int offset() {
+        return 0;
+    }
+
+    @Override
+    public Buffer offset(final int offset) {
+        return this;
+    }
+
+    @Override
+    public int limit() {
+        return 0;
+    }
+
+    @Override
+    public Buffer limit(final int limit) {
+        return this;
+    }
+
+    @Override
+    public int capacity() {
+        return 0;
+    }
+
+    @Override
+    public void setBytes(int index, byte[] source, int sourceIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void setBytes(int index, Buffer source, int sourceIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void getBytes(int index, byte[] dest, int destIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void getBytes(int index, Buffer dest, int destIndex, int length) {
+        return;
+    }
+
+    @Override
+    public void release() {
+        return;
+    }
+
+    private static final byte[] EMPTY_BYTES = new byte[0];
+}

--- a/src/main/java/org/embulk/util/file/FileInputInputStream.java
+++ b/src/main/java/org/embulk/util/file/FileInputInputStream.java
@@ -23,7 +23,7 @@ import org.embulk.spi.FileInput;
 public class FileInputInputStream extends InputStream {
     public FileInputInputStream(final FileInput in) {
         this.pos = 0;
-        this.buffer = EmptyBuffer.INSTANCE;
+        this.buffer = EmptyBuffer.getInstance();
 
         this.in = in;
     }
@@ -112,7 +112,7 @@ public class FileInputInputStream extends InputStream {
 
     private void releaseBuffer() {
         this.buffer.release();
-        this.buffer = EmptyBuffer.INSTANCE;
+        this.buffer = EmptyBuffer.getInstance();
         this.pos = 0;
     }
 

--- a/src/main/java/org/embulk/util/file/FileOutputOutputStream.java
+++ b/src/main/java/org/embulk/util/file/FileOutputOutputStream.java
@@ -86,7 +86,7 @@ public class FileOutputOutputStream extends OutputStream {
         if (this.pos > 0) {
             this.buffer.limit(this.pos);
             this.out.add(this.buffer);
-            this.buffer = EmptyBuffer.INSTANCE;
+            this.buffer = EmptyBuffer.getInstance();
             this.pos = 0;
             return true;
         }
@@ -121,7 +121,7 @@ public class FileOutputOutputStream extends OutputStream {
             default:  // Never default as all enums are listed.
         }
         this.buffer.release();
-        this.buffer = EmptyBuffer.INSTANCE;
+        this.buffer = EmptyBuffer.getInstance();
         this.pos = 0;
     }
 


### PR DESCRIPTION
This is a fix to deal with an issue https://github.com/embulk/embulk/issues/1409 that the library does not work well with Embulk v0.9.

The reason of this class structure is described at:
https://github.com/embulk/embulk-util-file/pull/13/files#diff-de61943700f059ae63ebc175aae5418df031ca2748bc08136c4fa518b64fbda2R32-R46