### PR TITLE
Fix EmptyBuffer for Embulk v0.10.27 or earlier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "org.embulk"
-version = "0.1.2-SNAPSHOT"
+version = "0.1.3-SNAPSHOT"
 description = "Embulk file-like byte sequence processor for Embulk plugins"
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
While `Class#getConstructor(...)` works only if the constructor is `public,` the constructor `Buffer()` has been `protected:`
https://github.com/embulk/embulk/blob/v0.10.27/embulk-api/src/main/java/org/embulk/spi/Buffer.java#L38-L39

Instead, calling `new EmptyBufferUpToDate()` directly, and catching `NoSuchMethodError`, in this PR.