### PR TITLE
Fix build.gradle to append "dependencies" if empty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,9 @@ publishing {
                 }
 
                 withXml {
+                    if (asNode().getAt("dependencies").isEmpty()) {
+                        asNode().appendNode("dependencies")
+                    }
                     project.configurations.compileOnly.allDependencies.each { dependency ->
                         asNode().dependencies[0].appendNode("dependency").with {
                             it.appendNode("groupId", dependency.group)


### PR DESCRIPTION
Releasing `embulk-util-file` 0.1.4 failed as of: 870a20b7a2e783b81dc276f934a1b7615281173d
https://github.com/embulk/embulk-util-file/actions/runs/4549267424

It was because `pom.xml` did not have any `<dependencies>` tag because it only had `compileOnly` dependencies. This is a quick fix.